### PR TITLE
Skip OLA universe rebuild on boot if mapping already matches

### DIFF
--- a/src/main/java/com/ascargon/rocketshow/lighting/DefaultLightingService.java
+++ b/src/main/java/com/ascargon/rocketshow/lighting/DefaultLightingService.java
@@ -91,8 +91,16 @@ public class DefaultLightingService implements LightingService {
                 capabilitiesService.getCapabilities().setOla(true);
                 reset();
             }
-            reconcileOlaPortIds();
-            initializeUniverses();
+            if (olaUniversesMatchDesiredMapping()) {
+                logger.debug("OLA universes already match desired mapping, skipping reconciliation and rebuild");
+                olaReady = getLightingUniverses().stream().anyMatch(u ->
+                        u.getOlaUniverseId() != null &&
+                        u.getOlaOutputPortId() != null && !u.getOlaOutputPortId().isBlank()
+                );
+            } else {
+                reconcileOlaPortIds();
+                initializeUniverses();
+            }
         } catch (Exception e) {
             logger.error("Could not initialize OLA client (attempt {}/{})", attempt, OLA_MAX_RETRIES, e);
         }
@@ -103,6 +111,68 @@ public class DefaultLightingService implements LightingService {
         } else if (olaReady) {
             olaRetryExecutor.shutdown();
         }
+    }
+
+    private boolean olaUniversesMatchDesiredMapping() {
+        List<LightingUniverse> lightingUniverses = getLightingUniverses();
+
+        UniverseInfoReply universeInfoReply = olaClient.getUniverseList();
+        if (universeInfoReply == null) {
+            return false;
+        }
+
+        Map<Integer, String> olaUniverseNames = new HashMap<>();
+        for (UniverseInfo universeInfo : universeInfoReply.getUniverseList()) {
+            olaUniverseNames.put(universeInfo.getUniverse(), universeInfo.hasName() ? universeInfo.getName() : "");
+        }
+
+        // Build map of portId -> assigned universeId from device info (includes bound ports)
+        Map<String, Integer> portAssignments = new HashMap<>();
+        Ola.DeviceInfoReply deviceInfoReply = olaClient.getDeviceInfo();
+        if (deviceInfoReply != null) {
+            for (Ola.DeviceInfo deviceInfo : deviceInfoReply.getDeviceList()) {
+                if (!deviceInfo.hasDeviceAlias()) {
+                    continue;
+                }
+                for (Ola.PortInfo outputPort : deviceInfo.getOutputPortList()) {
+                    if (outputPort.hasUniverse() && outputPort.hasPortId()) {
+                        String portId = deviceInfo.getDeviceAlias() + "-O-" + outputPort.getPortId();
+                        portAssignments.put(portId, outputPort.getUniverse());
+                    }
+                }
+            }
+        }
+
+        for (LightingUniverse universe : lightingUniverses) {
+            if (universe.getOlaUniverseId() == null) {
+                continue;
+            }
+
+            int olaId = universe.getOlaUniverseId();
+            String expectedName = getOlaUniverseName(universe);
+            String actualName = olaUniverseNames.get(olaId);
+
+            if (actualName == null) {
+                logger.debug("OLA universe {} does not exist yet", olaId);
+                return false;
+            }
+
+            if (!expectedName.equals(actualName)) {
+                logger.debug("OLA universe {} name mismatch: expected '{}', actual '{}'", olaId, expectedName, actualName);
+                return false;
+            }
+
+            if (universe.getOlaOutputPortId() != null && !universe.getOlaOutputPortId().isBlank()) {
+                Integer assignedUniverse = portAssignments.get(universe.getOlaOutputPortId());
+                if (!Integer.valueOf(olaId).equals(assignedUniverse)) {
+                    logger.debug("OLA port '{}' is not assigned to universe {} (currently assigned to: {})",
+                            universe.getOlaOutputPortId(), olaId, assignedUniverse);
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private List<OlaPort> fetchLiveOlaOutputPorts() throws Exception {

--- a/src/main/java/com/ascargon/rocketshow/lighting/DefaultLightingService.java
+++ b/src/main/java/com/ascargon/rocketshow/lighting/DefaultLightingService.java
@@ -819,9 +819,43 @@ public class DefaultLightingService implements LightingService {
         return String.join(", ", descriptions);
     }
 
+    private boolean olaPluginsMatchDesiredState(List<OlaPlugin> desiredPlugins) {
+        if (olaClient == null) {
+            return false;
+        }
+
+        Ola.PluginListReply pluginListReply = olaClient.getPlugins();
+        if (pluginListReply == null) {
+            return false;
+        }
+
+        for (Ola.PluginInfo pluginInfo : pluginListReply.getPluginList()) {
+            boolean shouldBeEnabled = desiredPlugins.stream()
+                    .anyMatch(p -> p.getName().equals(pluginInfo.getName()));
+
+            Ola.PluginStateReply stateReply = olaClient.getPluginState(pluginInfo.getPluginId());
+            if (stateReply == null || !stateReply.hasEnabled()) {
+                return false;
+            }
+
+            if (stateReply.getEnabled() != shouldBeEnabled) {
+                logger.debug("OLA plugin '{}' state mismatch: expected enabled={}, actual enabled={}",
+                        pluginInfo.getName(), shouldBeEnabled, stateReply.getEnabled());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     @Override
     public synchronized void reloadOlaPlugins() {
         if (olaClient == null) {
+            return;
+        }
+
+        if (olaPluginsMatchDesiredState(settingsService.getSettings().getLightingOlaPluginList())) {
+            logger.debug("OLA plugins already match desired state, skipping reload");
             return;
         }
 
@@ -831,7 +865,12 @@ public class DefaultLightingService implements LightingService {
 
     @Override
     public synchronized void enablePlugins(List<OlaPlugin> olaPluginList) {
-        // Disable all plugins, except the one to be enabled
+        if (olaPluginsMatchDesiredState(olaPluginList)) {
+            logger.debug("OLA plugins already match desired state, skipping enable");
+            return;
+        }
+
+        // Disable all plugins, except the ones to be enabled
         for (OlaPlugin olaPlugin : getOlaPlugins()) {
             boolean enabled = olaPluginList.stream().anyMatch(plugin -> plugin.getName().equals(olaPlugin.getName()));
             olaClient.setPluginState(olaPlugin.getId(), enabled);

--- a/src/main/java/com/ascargon/rocketshow/lighting/DefaultLightingService.java
+++ b/src/main/java/com/ascargon/rocketshow/lighting/DefaultLightingService.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import tools.jackson.databind.ObjectMapper;
 
@@ -77,7 +78,10 @@ public class DefaultLightingService implements LightingService {
 
         RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(5000).build();
         httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+    }
 
+    @PostConstruct
+    public void init() {
         if (OperatingSystemInformation.SubType.RASPBERRYOS.equals(this.operatingSystemInformationService.getOperatingSystemInformation().getSubType())) {
             olaRetryExecutor = Executors.newSingleThreadScheduledExecutor();
             tryInitializeOla(1);
@@ -85,6 +89,7 @@ public class DefaultLightingService implements LightingService {
     }
 
     private void tryInitializeOla(int attempt) {
+        logger.debug("Initialize OLA...");
         try {
             if (olaClient == null) {
                 olaClient = new OlaClient();
@@ -98,6 +103,7 @@ public class DefaultLightingService implements LightingService {
                         u.getOlaOutputPortId() != null && !u.getOlaOutputPortId().isBlank()
                 );
             } else {
+                logger.debug("Reconcile OLA ports/universes...");
                 reconcileOlaPortIds();
                 initializeUniverses();
             }

--- a/src/main/java/com/ascargon/rocketshow/midi/DefaultMidiDeviceInService.java
+++ b/src/main/java/com/ascargon/rocketshow/midi/DefaultMidiDeviceInService.java
@@ -15,7 +15,6 @@ import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiUnavailableException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;

--- a/src/main/java/com/ascargon/rocketshow/midi/DefaultMidiDeviceInService.java
+++ b/src/main/java/com/ascargon/rocketshow/midi/DefaultMidiDeviceInService.java
@@ -8,6 +8,7 @@ import purejavacomm.SerialPort;
 import purejavacomm.SerialPortEvent;
 import purejavacomm.SerialPortEventListener;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.MidiMessage;
@@ -42,8 +43,10 @@ public class DefaultMidiDeviceInService implements MidiDeviceInService {
 
         // Initialize the MIDI router
         midiRouter = midiRouterFactory.getMidiRouter(settingsService.getSettings().getDeviceInMidiRoutingList());
+    }
 
-        // Try to connect to MIDI in devices
+    @PostConstruct
+    public void init() {
         connectMidiDevices();
     }
 
@@ -86,7 +89,6 @@ public class DefaultMidiDeviceInService implements MidiDeviceInService {
         }
 
         MidiMessageParser parser = new MidiMessageParser();
-        ByteBuffer buffer = ByteBuffer.allocate(256);
         InputStream input = null;
 
         try {

--- a/src/main/java/com/ascargon/rocketshow/midi/DefaultMidiDeviceOutService.java
+++ b/src/main/java/com/ascargon/rocketshow/midi/DefaultMidiDeviceOutService.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import purejavacomm.SerialPort;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiUnavailableException;
@@ -27,8 +28,10 @@ public class DefaultMidiDeviceOutService implements MidiDeviceOutService {
     public DefaultMidiDeviceOutService(SettingsService settingsService, MidiService midiService) {
         this.settingsService = settingsService;
         this.midiService = midiService;
+    }
 
-        // Try to connect to the MIDI out devices
+    @PostConstruct
+    public void init() {
         connectMidiDevices();
     }
 

--- a/src/main/java/com/ascargon/rocketshow/settings/DefaultSettingsService.java
+++ b/src/main/java/com/ascargon/rocketshow/settings/DefaultSettingsService.java
@@ -10,6 +10,8 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.system.ApplicationHome;
@@ -62,6 +64,9 @@ public class DefaultSettingsService implements SettingsService {
 
         // Apply default settings (if not loaded)
         initDefaultSettings();
+
+        // Apply the log level early so subsequent bean initialization is logged correctly
+        applyLoggingLevel();
 
         // Save the settings to store migrations, default values, etc.
         try {
@@ -527,6 +532,22 @@ public class DefaultSettingsService implements SettingsService {
         // make sure, settings not available in the interface (e.g. the designer path)
         // are not lost
         this.initDefaultSettings();
+    }
+
+    private void applyLoggingLevel() {
+        if (settings == null || settings.getLoggingLevel() == null) {
+            return;
+        }
+
+        Level level = switch (settings.getLoggingLevel()) {
+            case DEBUG -> Level.DEBUG;
+            case TRACE -> Level.TRACE;
+            case WARN -> Level.WARN;
+            case ERROR -> Level.ERROR;
+            default -> Level.INFO;
+        };
+
+        Configurator.setLevel("com.ascargon.rocketshow", level);
     }
 
 }


### PR DESCRIPTION
On startup, check whether OLA already has the correct universe IDs, names, and port assignments before running the disruptive reconcile+clear+rebuild cycle. Only rebuild if something has changed.

https://claude.ai/code/session_019kzg17rJVHK78aYMDWvg88