### PR TITLE
Disable update in provision when not logged in

### DIFF
--- a/src/main/webapp/src/app/provision/provision.component.html
+++ b/src/main/webapp/src/app/provision/provision.component.html
@@ -146,8 +146,11 @@
         <div class="card-header">Update</div>
         <div class="card-body">
           <p class="mb-3">Check for available updates and install them.</p>
+          @if (!canUpdate) {
+          <p class="mb-3 text-muted">You need to be logged in to update this device.</p>
+          }
           <div class="d-flex float-right">
-            <button type="button" class="btn btn-primary" (click)="openUpdateDialog(); false">
+            <button type="button" class="btn btn-primary" (click)="openUpdateDialog(); false" [disabled]="!canUpdate">
               <i class="fa fa-download" aria-hidden="true"></i> Start update
             </button>
           </div>

--- a/src/main/webapp/src/app/provision/provision.component.ts
+++ b/src/main/webapp/src/app/provision/provision.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { DeviceInformation } from '../models/device-information';
 import { HealthStatus } from '../models/health-status';
+import { AuthService } from '../services/auth.service';
 import { DeviceInformationService } from '../services/device-information.service';
 import { HealthService } from '../services/health.service';
 import { ToastGeneralErrorService } from '../services/toast-general-error.service';
@@ -27,8 +28,17 @@ export class ProvisionComponent implements OnInit {
     private deviceInformationService: DeviceInformationService,
     private healthService: HealthService,
     private modalService: BsModalService,
-    private toastGeneralErrorService: ToastGeneralErrorService
+    private toastGeneralErrorService: ToastGeneralErrorService,
+    private authService: AuthService
   ) { }
+
+  // Updating is only possible while the device is still unprovisioned (no admin
+  // password set yet) or when an admin is logged in. Otherwise the backend
+  // rejects the update with an authorization error, so the button is disabled.
+  get canUpdate(): boolean {
+    const state = this.authService.currentState;
+    return !!state && (!state.passwordConfigured || state.authenticated);
+  }
 
   ngOnInit() {
     this.loadDeviceInformation();


### PR DESCRIPTION
The update endpoints are only authorized while the device is still
unprovisioned (no admin password set) or for a logged-in admin. When a
password is configured but the user is not logged in, starting an update
from the provisioning page failed with an authorization error.

Disable the update button (and show a hint) in that case, mirroring the
backend authorization rule.