### PR TITLE
Retry RAUC bundle installation on transient failures

### DIFF
--- a/src/main/java/com/ascargon/rocketshow/update/DefaultRaucService.java
+++ b/src/main/java/com/ascargon/rocketshow/update/DefaultRaucService.java
@@ -21,6 +21,13 @@ public class DefaultRaucService implements RaucService {
 
     private final UpdateNotificationService updateNotificationService;
 
+    // Installing a bundle can fail transiently (e.g. "Failed mounting bundle:
+    // Failed to load dm table" while setting up dm-verity). Retrying the same
+    // bundle usually succeeds immediately, so we attempt the installation
+    // multiple times before giving up.
+    private final static int MAX_INSTALL_ATTEMPTS = 5;
+    private final static long INSTALL_RETRY_DELAY_MILLIS = 5000;
+
     public DefaultRaucService(
             UpdateNotificationService updateNotificationService
     ) {
@@ -64,6 +71,30 @@ public class DefaultRaucService implements RaucService {
 
     @Override
     public void installBundle(String url) throws Exception {
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= MAX_INSTALL_ATTEMPTS; attempt++) {
+            try {
+                attemptInstallBundle(url);
+                // Installation succeeded
+                return;
+            } catch (Exception e) {
+                lastException = e;
+
+                if (attempt < MAX_INSTALL_ATTEMPTS) {
+                    logger.warn("RAUC bundle installation failed (attempt {} of {}). Retrying in {} ms...",
+                            attempt, MAX_INSTALL_ATTEMPTS, INSTALL_RETRY_DELAY_MILLIS, e);
+                    Thread.sleep(INSTALL_RETRY_DELAY_MILLIS);
+                } else {
+                    logger.error("RAUC bundle installation failed after {} attempts.", MAX_INSTALL_ATTEMPTS);
+                }
+            }
+        }
+
+        throw lastException;
+    }
+
+    private void attemptInstallBundle(String url) throws Exception {
         Pattern PROGRESS_PATTERN =
                 Pattern.compile("^\\s*(\\d{1,3})%\\s+(.*?)(?:\\s+done\\.)?\\s*$");
 
@@ -76,30 +107,34 @@ public class DefaultRaucService implements RaucService {
         int lastPercentage = -1;
         String lastMessage = null;
 
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+        try {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
 
-            String line;
-            while ((line = reader.readLine()) != null) {
-                logger.info("RAUC output: {}", line);
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    logger.info("RAUC output: {}", line);
 
-                Matcher matcher = PROGRESS_PATTERN.matcher(line);
-                if (matcher.matches()) {
-                    lastPercentage = Integer.parseInt(matcher.group(1));
-                    lastMessage = matcher.group(2).trim();
+                    Matcher matcher = PROGRESS_PATTERN.matcher(line);
+                    if (matcher.matches()) {
+                        lastPercentage = Integer.parseInt(matcher.group(1));
+                        lastMessage = matcher.group(2).trim();
 
-                    UpdateState updateState = new UpdateState();
-                    updateState.setProgressPercentage(lastPercentage);
-                    updateState.setProgressMessage(lastMessage);
-                    updateNotificationService.notifyClients(updateState);
+                        UpdateState updateState = new UpdateState();
+                        updateState.setProgressPercentage(lastPercentage);
+                        updateState.setProgressMessage(lastMessage);
+                        updateNotificationService.notifyClients(updateState);
+                    }
                 }
             }
-        }
 
-        int exitCode = process.waitFor();
+            int exitCode = process.waitFor();
 
-        if (exitCode != 0) {
-            throw new Exception("RAUC exited with exit code " + exitCode);
+            if (exitCode != 0) {
+                throw new Exception("RAUC exited with exit code " + exitCode);
+            }
+        } finally {
+            shellManager.close();
         }
     }
 


### PR DESCRIPTION
## Problem

RAUC bundle installation occasionally fails with a transient error while setting up the dm-verity mount, e.g.:

```
100% Installing failed.
LastError: Failed mounting bundle: Failed to load dm table: Argument list too long, check DM_VERITY, DM_CRYPT or CRYPTO_AES kernel options.
Installing `.../update-....raucb` failed
```

Retrying the exact same bundle immediately usually succeeds. This was reproduced across two different hosters, so it's not related to file serving. Since dm-verity is required for streaming, disabling it isn't an option — retrying is the appropriate fix.

## Change

In `DefaultRaucService`:

- Extracted the original single-attempt install logic into a private `attemptInstallBundle(url)`.
- `installBundle()` now wraps it in a retry loop: up to **5 attempts** with a **5s delay** between them (configurable via the new `MAX_INSTALL_ATTEMPTS` / `INSTALL_RETRY_DELAY_MILLIS` constants). Failing attempts are logged as warnings; only after all attempts are exhausted is the last exception thrown.
- Added a per-attempt `finally { shellManager.close() }` so retries don't leak the RAUC process.

The downstream failure path in `DefaultUpdateService` (`"Unable to install RAUC bundle"`) and the UI behavior are unchanged — retries simply happen before it.

## Notes

The retry currently triggers on any installation failure, not only the dm-verity error. A genuinely bad bundle (e.g. signature failure) would therefore retry 5× and add ~20s before failing. This was a deliberate choice to avoid brittle parsing of `LastError` strings; happy to narrow it to the specific mount/dm-table error if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGyMZtf8xd4x56ZdurTaJb)_