### PR TITLE
Persist update status across page reloads

### DIFF
--- a/src/main/webapp/src/app/app.component.html
+++ b/src/main/webapp/src/app/app.component.html
@@ -1,3 +1,8 @@
+<!-- Update in progress: block everything else until the update is done or failed -->
+@if (isUpdating) {
+<app-update-progress></app-update-progress>
+} @else {
+
 <!-- Login -->
 @if (authService.initiallyLoaded && !isIntro && !isProvision && !authService.currentState?.authenticated) {
 <app-login></app-login>
@@ -97,4 +102,6 @@
 <!-- Main content -->
 @if ((loaded && authService.currentState?.authenticated) || isIntro || isProvision) {
 <router-outlet></router-outlet>
+}
+
 }

--- a/src/main/webapp/src/app/app.component.ts
+++ b/src/main/webapp/src/app/app.component.ts
@@ -13,6 +13,8 @@ import { OperatingSystemInformationService } from "./services/operating-system-i
 import { AuthService } from "./services/auth.service";
 import { DeviceInformationService } from "./services/device-information.service";
 import { ToastrService } from "ngx-toastr";
+import { UpdateService } from "./services/update.service";
+import { UpdateState } from "./models/update-state";
 
 @Component({
   selector: "body",
@@ -25,6 +27,7 @@ export class AppComponent implements OnInit {
   isIntro: boolean = false;
   isProvision: boolean = false;
   isPlay: boolean = false;
+  isUpdating: boolean = false;
   loaded: boolean = false;
   settings: Settings;
   mobileAppHost: boolean = false;
@@ -42,7 +45,8 @@ export class AppComponent implements OnInit {
     private operatingSystemInformationService: OperatingSystemInformationService,
     private route: ActivatedRoute,
     public authService: AuthService,
-    private toastrService: ToastrService
+    private toastrService: ToastrService,
+    private updateService: UpdateService
   ) {
     translateService.setDefaultLang("en");
   }
@@ -56,6 +60,20 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
+    // If an update is currently in progress (e.g. the page was reloaded while
+    // updating), show the full-screen update status and block everything else
+    // until the update is done or failed. The update-state endpoint is public,
+    // so this also works while rebooting into a new slot without a session.
+    this.updateService.getUpdateState().subscribe((updateState: UpdateState) => {
+      if (
+        updateState.step === "UPDATING" ||
+        updateState.step === "REBOOTING" ||
+        updateState.step === "FALLING_BACK"
+      ) {
+        this.isUpdating = true;
+      }
+    });
+
     this.router.events.subscribe((e) => {
       if (e instanceof NavigationEnd) {
         const mobileAppHost =

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { WaitDialogService } from "./services/wait-dialog.service";
 import { AppComponent } from "./app.component";
 import { IntroComponent } from "./intro/intro.component";
 import { ProvisionComponent } from "./provision/provision.component";
+import { UpdateProgressComponent } from "./update-progress/update-progress.component";
 import { ConnectionComponent } from "./connection/connection.component";
 import { PlayComponent } from "./play/play.component";
 import { SettingsComponent } from "./settings/settings.component";
@@ -142,6 +143,7 @@ const appRoutes: Routes = [
         WarningDialogComponent,
         SettingsAdvancedComponent,
         UpdateDialogComponent,
+        UpdateProgressComponent,
         BackupRestoreDialogComponent,
         WaitDialogComponent,
         InfoDialogComponent,

--- a/src/main/webapp/src/app/update-progress/update-progress.component.html
+++ b/src/main/webapp/src/app/update-progress/update-progress.component.html
@@ -1,0 +1,49 @@
+<div class="container d-flex h-100">
+  <div class="row justify-content-center align-self-center mx-auto">
+    <div class="col">
+      <div class="card border-secondary">
+        <div class="card-header">
+          {{ 'misc.update' | translate }}
+        </div>
+        <div class="card-body">
+          @if (!updateFinished && !updateError) {
+          <p>
+            <i>{{ 'settings.update-hint' | translate }}</i>
+          </p>
+          <div class="progress">
+            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
+              [style.width]="updatePerc + '%'"></div>
+          </div>
+          <p class="text-center mt-2 mb-0">
+            <i class="fa fa-spinner fa-pulse fa-fw"></i> {{ updateStep | translate }}
+          </p>
+          }
+
+          @if (updateFinished) {
+          <h1 class="text-center text-success">
+            <i class="fa fa-check-circle-o fa-2x" aria-hidden="true"></i>
+          </h1>
+          <p class="text-center mt-2">{{ 'settings.update-finished' | translate }}</p>
+          <div class="d-flex justify-content-center">
+            <button type="button" class="btn btn-primary" (click)="reload(); false">
+              {{ 'misc.ok' | translate }}
+            </button>
+          </div>
+          }
+
+          @if (updateError) {
+          <h1 class="text-center text-danger">
+            <i class="fa fa-exclamation-circle fa-2x" aria-hidden="true"></i>
+          </h1>
+          <p class="text-center mt-2">{{ 'settings.update-error' | translate }}</p>
+          <div class="d-flex justify-content-center">
+            <button type="button" class="btn btn-primary" (click)="reload(); false">
+              {{ 'misc.ok' | translate }}
+            </button>
+          </div>
+          }
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/webapp/src/app/update-progress/update-progress.component.ts
+++ b/src/main/webapp/src/app/update-progress/update-progress.component.ts
@@ -1,0 +1,113 @@
+import { Subscription } from 'rxjs';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { UpdateState } from '../models/update-state';
+import { UpdateService } from '../services/update.service';
+import { UpdateStateService } from '../services/update-state.service';
+import { ReloadClearCacheService } from '../services/reload-clear-cache.service';
+import { ToastGeneralErrorService } from '../services/toast-general-error.service';
+
+// Full-screen update status, shown while an update is in progress. It survives a
+// page reload (the app detects the ongoing update and renders this component), so
+// the user always sees the current status until the update is done or failed and
+// cannot navigate away from it in the meantime.
+@Component({
+  selector: 'app-update-progress',
+  templateUrl: './update-progress.component.html',
+  styleUrls: ['./update-progress.component.scss'],
+  standalone: false
+})
+export class UpdateProgressComponent implements OnInit, OnDestroy {
+
+  updateStep: string = 'settings.update-install';
+  updatePerc: number = 0;
+  updateFinished: boolean = false;
+  updateError: boolean = false;
+
+  private updateStateServiceSubscription: Subscription;
+  private pollStateInterval: any;
+
+  constructor(
+    private updateService: UpdateService,
+    private updateStateService: UpdateStateService,
+    private reloadClearCacheService: ReloadClearCacheService,
+    private toastGeneralErrorService: ToastGeneralErrorService,
+  ) { }
+
+  ngOnInit() {
+    this.updateStateServiceSubscription = this.updateStateService.updateState.subscribe((updateState: UpdateState) => {
+      this.processUpdateState(updateState);
+    });
+
+    // Seed the current state, because the websocket only pushes future changes
+    // (e.g. right after a page reload there might not be a new state for a while).
+    this.updateService.getUpdateState().subscribe((updateState) => {
+      this.processUpdateState(updateState);
+    });
+  }
+
+  private finishUpdateSuccess() {
+    this.updateFinished = true;
+    this.updatePerc = 100;
+  }
+
+  private finishUpdateError(error: string) {
+    this.updateError = true;
+    this.toastGeneralErrorService.show(new Error(error));
+  }
+
+  private processUpdateState(updateState: UpdateState) {
+    if (updateState.step === 'REBOOTING' || updateState.step === 'FALLING_BACK') {
+      this.updateStep = 'settings.update-reboot';
+      this.updatePerc = 99;
+
+      // Don't rely on states pushed from the backend, because it's rebooting now
+      // and we might not be able to reconnect to the websocket in time. Instead, poll
+      // for a new status until the update is finished.
+      if (this.updateStateServiceSubscription) {
+        this.updateStateServiceSubscription.unsubscribe();
+        this.updateStateServiceSubscription = undefined;
+      }
+
+      if (!this.pollStateInterval) {
+        this.pollStateInterval = setInterval(() => {
+          this.updateService.getUpdateState().subscribe((polledState) => {
+            if (polledState.step === 'FINISHED') {
+              clearInterval(this.pollStateInterval);
+              this.pollStateInterval = undefined;
+            }
+            this.processUpdateState(polledState);
+          });
+        }, 5000);
+      }
+    } else if (updateState.step === 'FINISHED') {
+      if (updateState.error) {
+        this.finishUpdateError(updateState.error);
+      } else {
+        this.finishUpdateSuccess();
+      }
+    } else {
+      this.updateStep = 'settings.update-install';
+      if (updateState.progressPercentage > 98) {
+        this.updatePerc = 98;
+      } else {
+        this.updatePerc = updateState.progressPercentage;
+      }
+    }
+  }
+
+  public reload(): void {
+    // Reload the page (caching has been disabled in Angular CLI and we
+    // therefore automatically receive the new version of the app)
+    this.reloadClearCacheService.reload();
+  }
+
+  ngOnDestroy() {
+    if (this.updateStateServiceSubscription) {
+      this.updateStateServiceSubscription.unsubscribe();
+    }
+    if (this.pollStateInterval) {
+      clearInterval(this.pollStateInterval);
+    }
+  }
+
+}

--- a/src/main/webapp/src/assets/i18n/de.json
+++ b/src/main/webapp/src/assets/i18n/de.json
@@ -236,6 +236,7 @@
     "update-install": "Installieren...",
     "update-reboot": "Neu starten...",
     "update-finished": "Die Aktualisierung wurde erfolgreich abgeschlossen.",
+    "update-error": "Die Aktualisierung ist fehlgeschlagen.",
     "reboot-device": "Neu starten",
     "shutdown-device": "Herunterfahren",
     "default-composition": "Standard-Komposition",

--- a/src/main/webapp/src/assets/i18n/en.json
+++ b/src/main/webapp/src/assets/i18n/en.json
@@ -236,6 +236,7 @@
     "update-install": "Installing...",
     "update-reboot": "Rebooting...",
     "update-finished": "The update has finished successfully.",
+    "update-error": "The update failed.",
     "reboot-device": "Reboot",
     "shutdown-device": "Shutdown",
     "default-composition": "Default composition",

--- a/src/main/webapp/src/assets/i18n/es.json
+++ b/src/main/webapp/src/assets/i18n/es.json
@@ -235,6 +235,7 @@
     "update-install": "Instalando...",
     "update-reboot": "Reiniciando...",
     "update-finished": "La actualización se ha completado correctamente.",
+    "update-error": "La actualización ha fallado.",
     "reboot-device": "Reiniciar",
     "shutdown-device": "Apagar",
     "default-composition": "Composición predeterminada",

--- a/src/main/webapp/src/assets/i18n/fr.json
+++ b/src/main/webapp/src/assets/i18n/fr.json
@@ -235,6 +235,7 @@
     "update-install": "Installation...",
     "update-reboot": "Redémarrage...",
     "update-finished": "La mise à jour s'est terminée avec succès.",
+    "update-error": "La mise à jour a échoué.",
     "reboot-device": "Redémarrer",
     "shutdown-device": "Éteindre",
     "default-composition": "Composition par défaut",

--- a/src/main/webapp/src/assets/i18n/it.json
+++ b/src/main/webapp/src/assets/i18n/it.json
@@ -235,6 +235,7 @@
     "update-install": "Installazione...",
     "update-reboot": "Riavvio...",
     "update-finished": "L'aggiornamento è stato completato con successo.",
+    "update-error": "L'aggiornamento non è riuscito.",
     "reboot-device": "Riavvia",
     "shutdown-device": "Spegni",
     "default-composition": "Composizione predefinita",

--- a/src/main/webapp/src/assets/i18n/pt.json
+++ b/src/main/webapp/src/assets/i18n/pt.json
@@ -235,6 +235,7 @@
     "update-install": "A instalar...",
     "update-reboot": "A reiniciar...",
     "update-finished": "A atualização foi concluída com sucesso.",
+    "update-error": "A atualização falhou.",
     "reboot-device": "Reiniciar",
     "shutdown-device": "Desligar",
     "default-composition": "Composição predefinida",

--- a/src/main/webapp/src/assets/i18n/zh.json
+++ b/src/main/webapp/src/assets/i18n/zh.json
@@ -235,6 +235,7 @@
     "update-install": "正在安装...",
     "update-reboot": "正在重启...",
     "update-finished": "更新已成功完成。",
+    "update-error": "更新失败。",
     "reboot-device": "重启",
     "shutdown-device": "关机",
     "default-composition": "默认作品",


### PR DESCRIPTION
## Problem

When a device update is running, reloading the page dropped the user back into the normal app. They could play as usual but no longer saw the update status — and then the device would suddenly reboot, which is confusing.

## Changes

- **New full-screen `UpdateProgressComponent`** that shows the update status and blocks everything else, similar to the provisioning page. It seeds its state from the public `update-state` endpoint (so it works even while rebooting into a new slot without a session), tracks progress over the websocket, and polls during the reboot. When the update is done or fails it shows a success/error message with a reload button.
- **`AppComponent`** now checks the update state on load and, if an update is in progress (`UPDATING` / `REBOOTING` / `FALLING_BACK`), renders the full-screen status instead of the app. This blocks all navigation until the update is done or failed — so a reload during an update keeps the user on the status.
- **Translations**: added the `settings.update-error` key in all locales (en, de, es, fr, it, pt, zh).

## Notes

The update **dialog** already prevents closing while updating — its OK button stays disabled until the update is done or fails, and the modal ignores the backdrop/escape — so requirement 1 ("don't allow closing the update dialog during update") was already satisfied and left as-is.

## Testing

- `ng build` compiles cleanly (only pre-existing Sass `@import` deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNcWszzttWd3xnEtMYSWoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNcWszzttWd3xnEtMYSWoZ)_