### PR TITLE
Add open source licensing information to Settings → Info

### DIFF
--- a/src/main/webapp/src/app/settings/settings-info/settings-info.component.html
+++ b/src/main/webapp/src/app/settings/settings-info/settings-info.component.html
@@ -15,3 +15,42 @@
   <label class="col-lg-3 col-form-label">{{ "settings.build-number" | translate }}</label>
   <div class="col-lg-9 col-form-label">{{ buildInfo?.buildNumber }}</div>
 </div>
+
+<hr>
+
+<h4>{{ "settings.licenses.title" | translate }}</h4>
+
+<p>{{ "settings.licenses.intro" | translate }}</p>
+
+<div class="form-group row">
+  <label class="col-lg-3 col-form-label">{{ "settings.licenses.license" | translate }}</label>
+  <div class="col-lg-9 col-form-label">
+    <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">GNU General Public License v3.0</a>
+  </div>
+</div>
+
+<div class="form-group row">
+  <label class="col-lg-3 col-form-label">{{ "settings.licenses.source-code" | translate }}</label>
+  <div class="col-lg-9 col-form-label">
+    <a href="https://github.com/Rocket-Show/rocketshow" target="_blank">github.com/Rocket-Show/rocketshow</a>
+  </div>
+</div>
+
+<p>{{ "settings.licenses.install-info" | translate }}</p>
+
+<h5>{{ "settings.licenses.third-party" | translate }}</h5>
+
+<p>{{ "settings.licenses.third-party-intro" | translate }}</p>
+
+<ul>
+  <li>Spring Framework / Spring Boot &mdash; Apache License 2.0</li>
+  <li>Apache HttpClient, Apache Commons IO, Apache Commons FileUpload &mdash; Apache License 2.0</li>
+  <li>Google Protocol Buffers (protobuf-java) &mdash; BSD 3-Clause License</li>
+  <li>Pi4J (core, Raspberry Pi and gpiod plugins) &mdash; Apache License 2.0</li>
+  <li>Jakarta XML Binding (JAXB) API and runtime &mdash; Eclipse Distribution License 1.0 (BSD)</li>
+  <li>Jakarta Activation &mdash; Eclipse Distribution License 1.0 (BSD)</li>
+  <li>PureJavaComm &mdash; BSD 2-Clause License</li>
+  <li>Open Lighting Architecture (OLA) Java client &mdash; GNU Lesser General Public License 2.1</li>
+  <li>GStreamer and gst1-java-core &mdash; GNU Lesser General Public License 2.1 (some plugins are licensed under the GPL)</li>
+  <li>Angular and web application dependencies &mdash; MIT License</li>
+</ul>

--- a/src/main/webapp/src/assets/i18n/en.json
+++ b/src/main/webapp/src/assets/i18n/en.json
@@ -350,7 +350,16 @@
     "secure-connection-enable": "Activated",
     "build-date": "Build date",
     "build-timestamp": "Build timestamp",
-    "build-number": "Build number"
+    "build-number": "Build number",
+    "licenses": {
+      "title": "Open Source Licenses",
+      "intro": "Rocket Show is free and open source software, licensed under the GNU General Public License v3.0. It is distributed with no warranty, to the extent permitted by law.",
+      "license": "License",
+      "source-code": "Source code",
+      "install-info": "The complete corresponding source code is available at the link above. In accordance with the license, you are free to run, study, modify and redistribute this software. You may build your own image and install a modified version on this device.",
+      "third-party": "Third-party components",
+      "third-party-intro": "Rocket Show includes the following open source components, which remain under their respective licenses:"
+    }
   },
   "action": {
     "action": "Action",


### PR DESCRIPTION
## Summary

Adds an **Open Source Licenses** section to the **Settings → Info** page so that devices shipping Rocket Show can surface the required license and attribution information directly in the software.

This helps satisfy the obligations that apply when Rocket Show is distributed (e.g. pre-installed on a device), even when the software itself is unmodified.

## What it shows

- A statement that Rocket Show is free software licensed under the **GNU General Public License v3.0**, distributed with no warranty
- **License** row linking to the full GPLv3 text
- **Source code** row linking to the public repository (satisfies the source-availability requirement)
- A note that users may build their own image and install a modified version on the device (covers GPLv3 §6 "Installation Information" / anti-tivoization)
- A **Third-party components** list with each bundled dependency and its license:
  - Spring Framework / Spring Boot, Apache HttpClient, Commons IO / FileUpload, Pi4J — Apache License 2.0
  - Protocol Buffers, PureJavaComm — BSD
  - JAXB / Jakarta Activation — Eclipse Distribution License 1.0 (BSD)
  - Open Lighting Architecture (OLA) client, GStreamer / gst1-java-core — LGPL 2.1
  - Angular and web app dependencies — MIT

## Changes

- `settings-info.component.html` — new licensing UI, reusing the existing `translate` pipe and Bootstrap form-row layout already used on the page
- `assets/i18n/en.json` — new `settings.licenses.*` translation keys

The descriptive labels use i18n keys (matching the app convention); library and license names are hardcoded as proper nouns. Only `en.json` needed new keys — the app calls `setDefaultLang("en")`, so the other locales fall back to English automatically.

## Testing

- `en.json` validated as well-formed JSON.
- A full Angular build was not run because `node_modules` is not installed in this environment (per the README this requires `npm install --force`). The template change is purely additive and only uses constructs already present in the file.

## Not covered by this change

These are separate from the in-software notice and worth handling independently when distributing devices:
- Keeping the exact shipped source archived/available for as long as the device is sold
- Trademark of the "Rocket Show" name/branding
- Any codec patent considerations for GStreamer plugins bundled in the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nDPCeWJgCFrzq25tRmZH8

---
_Generated by [Claude Code](https://claude.ai/code/session_019nDPCeWJgCFrzq25tRmZH8)_