### PR TITLE
Add on-device system self-test, MIDI/lighting unit tests, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  test:
+    name: Build & test (backend)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Run the Java unit tests only. The Angular frontend build (frontend-maven-plugin)
+      # is skipped here to keep CI fast and free of a Node toolchain; it still runs as part
+      # of the regular packaging build.
+      - name: Run tests
+        run: ./mvnw -B -Dskip.installnodenpm=true -Dskip.npm=true test

--- a/src/main/java/com/ascargon/rocketshow/api/SystemController.java
+++ b/src/main/java/com/ascargon/rocketshow/api/SystemController.java
@@ -4,6 +4,7 @@ import com.ascargon.rocketshow.composition.CompositionService;
 import com.ascargon.rocketshow.composition.SetService;
 import com.ascargon.rocketshow.health.HealthService;
 import com.ascargon.rocketshow.health.HealthStatus;
+import com.ascargon.rocketshow.health.SystemTestResult;
 import com.ascargon.rocketshow.lighting.LightingService;
 import com.ascargon.rocketshow.lighting.LightingUniverse;
 import com.ascargon.rocketshow.lighting.OlaPlugin;
@@ -343,9 +344,8 @@ class SystemController {
     }
 
     @PostMapping("test")
-    public ResponseEntity<Void> test() {
-        healthService.testSystem();
-        return new ResponseEntity<>(HttpStatus.OK);
+    public SystemTestResult test() {
+        return healthService.testSystem();
     }
 
 }

--- a/src/main/java/com/ascargon/rocketshow/health/DefaultHealthService.java
+++ b/src/main/java/com/ascargon/rocketshow/health/DefaultHealthService.java
@@ -31,6 +31,7 @@ public class DefaultHealthService implements HealthService {
     private final RaucService raucService;
     private final DeviceInformationService deviceInformationService;
     private final EepromService eepromService;
+    private final SystemTestService systemTestService;
 
     public DefaultHealthService(
             HdmiService hdmiService,
@@ -41,7 +42,8 @@ public class DefaultHealthService implements HealthService {
             VersionService versionService,
             RaucService raucService,
             DeviceInformationService deviceInformationService,
-            EepromService eepromService
+            EepromService eepromService,
+            SystemTestService systemTestService
     ) {
         this.hdmiService = hdmiService;
         this.diskSpaceService = diskSpaceService;
@@ -52,6 +54,7 @@ public class DefaultHealthService implements HealthService {
         this.raucService = raucService;
         this.deviceInformationService = deviceInformationService;
         this.eepromService = eepromService;
+        this.systemTestService = systemTestService;
     }
 
     private void addReason(HealthStatus healthStatus, String reason) {
@@ -177,10 +180,8 @@ public class DefaultHealthService implements HealthService {
     }
 
     @Override
-    public void testSystem() {
-        // TODO play the default composition and check for errors
-        // TODO periodically change GPIO output status (e.g. each 3 seconds)
-        // TODO Send MIDI messages, expect the same MIDI messages
+    public SystemTestResult testSystem() {
+        return systemTestService.runSystemTest();
     }
 
 }

--- a/src/main/java/com/ascargon/rocketshow/health/DefaultSystemTestService.java
+++ b/src/main/java/com/ascargon/rocketshow/health/DefaultSystemTestService.java
@@ -1,0 +1,297 @@
+package com.ascargon.rocketshow.health;
+
+import com.ascargon.rocketshow.composition.Composition;
+import com.ascargon.rocketshow.composition.CompositionService;
+import com.ascargon.rocketshow.midi.MidiDeviceInService;
+import com.ascargon.rocketshow.midi.MidiDeviceOutService;
+import com.ascargon.rocketshow.play.CompositionPlayer;
+import com.ascargon.rocketshow.play.PlayerService;
+import com.ascargon.rocketshow.raspberry.ActionRaspberryGpio;
+import com.ascargon.rocketshow.raspberry.RaspberryGpioOutService;
+import com.ascargon.rocketshow.settings.SettingsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.Transmitter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class DefaultSystemTestService implements SystemTestService {
+
+    private final static Logger logger = LoggerFactory.getLogger(DefaultSystemTestService.class);
+
+    // How long to let the default composition play before checking its play state
+    private static final long COMPOSITION_PLAY_MILLIS = 2000;
+    // How long to hold each GPIO output state before switching it
+    private static final long GPIO_TOGGLE_MILLIS = 500;
+    // How long to wait for the MIDI loopback messages to arrive
+    private static final long MIDI_LOOPBACK_TIMEOUT_MILLIS = 1000;
+
+    // The notes sent during the MIDI loopback test (C4, E4, G4)
+    private static final int[] MIDI_TEST_NOTES = {60, 64, 67};
+
+    private final SettingsService settingsService;
+    private final CompositionService compositionService;
+    private final PlayerService playerService;
+    private final MidiDeviceInService midiDeviceInService;
+    private final MidiDeviceOutService midiDeviceOutService;
+    private final RaspberryGpioOutService raspberryGpioOutService;
+
+    public DefaultSystemTestService(
+            SettingsService settingsService,
+            CompositionService compositionService,
+            PlayerService playerService,
+            MidiDeviceInService midiDeviceInService,
+            MidiDeviceOutService midiDeviceOutService,
+            RaspberryGpioOutService raspberryGpioOutService
+    ) {
+        this.settingsService = settingsService;
+        this.compositionService = compositionService;
+        this.playerService = playerService;
+        this.midiDeviceInService = midiDeviceInService;
+        this.midiDeviceOutService = midiDeviceOutService;
+        this.raspberryGpioOutService = raspberryGpioOutService;
+    }
+
+    @Override
+    public SystemTestResult runSystemTest() {
+        logger.info("Running system self-test");
+
+        SystemTestResult result = new SystemTestResult();
+        result.addStep(testDefaultComposition());
+        result.addStep(testGpioOutputs());
+        result.addStep(testMidiLoopback());
+
+        logger.info("System self-test finished. Success: {}", result.isSuccess());
+
+        return result;
+    }
+
+    // Play the configured default composition and make sure it actually starts playing
+    // (i.e. the audio/video/lighting pipeline could be set up without errors).
+    SystemTestStep testDefaultComposition() {
+        String name = "Default composition playback";
+
+        String defaultCompositionName = settingsService.getSettings().getDefaultComposition();
+
+        if (defaultCompositionName == null || defaultCompositionName.isEmpty()) {
+            return skipped(name, "No default composition configured");
+        }
+
+        Composition composition = compositionService.getComposition(defaultCompositionName);
+
+        if (composition == null) {
+            return failed(name, "Default composition '" + defaultCompositionName + "' not found");
+        }
+
+        boolean started = false;
+
+        try {
+            playerService.playTestComposition(composition);
+            started = true;
+
+            sleep(COMPOSITION_PLAY_MILLIS);
+
+            CompositionPlayer.PlayState playState = getTestCompositionPlayState();
+
+            if (playState == CompositionPlayer.PlayState.PLAYING) {
+                return passed(name, "Played default composition '" + defaultCompositionName + "'");
+            }
+
+            return failed(name, "Default composition did not reach the playing state (was " + playState + ")");
+        } catch (Exception e) {
+            logger.error("System test: default composition playback failed", e);
+            return failed(name, "Error while playing the default composition: " + e.getMessage());
+        } finally {
+            if (started) {
+                try {
+                    playerService.stopTestComposition();
+                } catch (Exception e) {
+                    logger.error("System test: could not stop the default composition again", e);
+                }
+            }
+        }
+    }
+
+    // Toggle every configured GPIO output pin high and back to low so it can be verified
+    // (e.g. with an LED or a loopback wire to an input).
+    SystemTestStep testGpioOutputs() {
+        String name = "GPIO outputs";
+
+        if (!settingsService.getSettings().getEnableRaspberryGpio()) {
+            return skipped(name, "GPIO is disabled in the settings");
+        }
+
+        List<Integer> pins = settingsService.getSettings().getRaspberryGpioOutputPinBcmList();
+
+        if (pins == null || pins.isEmpty()) {
+            return skipped(name, "No GPIO output pins configured");
+        }
+
+        try {
+            for (Integer pin : pins) {
+                setGpio(pin, true);
+                sleep(GPIO_TOGGLE_MILLIS);
+                setGpio(pin, false);
+            }
+
+            return passed(name, "Toggled " + pins.size() + " GPIO output pin(s)");
+        } catch (Exception e) {
+            logger.error("System test: GPIO output test failed", e);
+            return failed(name, "Error while toggling the GPIO outputs: " + e.getMessage());
+        }
+    }
+
+    // Send a few MIDI messages to the MIDI out device and verify that the same messages
+    // arrive on the MIDI in device (requires a MIDI loopback cable).
+    SystemTestStep testMidiLoopback() {
+        String name = "MIDI loopback";
+
+        if (!midiDeviceOutService.isConnected()) {
+            return skipped(name, "No MIDI out device connected");
+        }
+
+        try {
+            List<MidiMessage> messages = buildTestMidiMessages();
+            List<byte[]> received = sendAndCaptureMidi(messages);
+
+            if (received == null) {
+                return skipped(name, "No MIDI in device available to verify the loopback");
+            }
+
+            if (midiMessagesMatch(toByteList(messages), received)) {
+                return passed(name, "Sent and received " + messages.size() + " MIDI message(s)");
+            }
+
+            return failed(name, "MIDI loopback mismatch. Sent " + messages.size()
+                    + " message(s), received " + received.size());
+        } catch (Exception e) {
+            logger.error("System test: MIDI loopback test failed", e);
+            return failed(name, "Error during the MIDI loopback test: " + e.getMessage());
+        }
+    }
+
+    private List<MidiMessage> buildTestMidiMessages() throws Exception {
+        List<MidiMessage> messages = new ArrayList<>();
+
+        for (int note : MIDI_TEST_NOTES) {
+            messages.add(new ShortMessage(ShortMessage.NOTE_ON, 0, note, 100));
+        }
+
+        return messages;
+    }
+
+    // Send the given messages to the MIDI out device and capture everything that arrives
+    // on the MIDI in device until all messages are received or a timeout elapses.
+    // Returns null if there is no (non-serial) MIDI in device to capture from.
+    //
+    // Extracted as a protected method so the hardware interaction can be stubbed in tests.
+    protected List<byte[]> sendAndCaptureMidi(List<MidiMessage> messages) throws Exception {
+        MidiDevice inDevice = midiDeviceInService.getMidiDevice();
+
+        if (inDevice == null) {
+            return null;
+        }
+
+        List<byte[]> received = Collections.synchronizedList(new ArrayList<>());
+
+        // getTransmitter() returns a new transmitter on every call, so capturing here does
+        // not interfere with the regular MIDI in routing.
+        Transmitter transmitter = inDevice.getTransmitter();
+        transmitter.setReceiver(new Receiver() {
+            @Override
+            public void send(MidiMessage message, long timeStamp) {
+                received.add(message.getMessage());
+            }
+
+            @Override
+            public void close() {
+                // nothing to do
+            }
+        });
+
+        try {
+            for (MidiMessage message : messages) {
+                midiDeviceOutService.sendMessage(message);
+            }
+
+            long deadline = System.currentTimeMillis() + MIDI_LOOPBACK_TIMEOUT_MILLIS;
+
+            while (received.size() < messages.size() && System.currentTimeMillis() < deadline) {
+                sleep(20);
+            }
+        } finally {
+            transmitter.close();
+        }
+
+        return new ArrayList<>(received);
+    }
+
+    // Extracted as a protected method so the play state can be stubbed in tests without
+    // having to mock the CompositionPlayer.
+    protected CompositionPlayer.PlayState getTestCompositionPlayState() {
+        return playerService.getTestCompositionPlayer().getPlayState();
+    }
+
+    private void setGpio(int pinId, boolean high) {
+        ActionRaspberryGpio action = new ActionRaspberryGpio();
+        action.setPinId(pinId);
+        action.setHigh(high);
+        raspberryGpioOutService.executeAction(action);
+    }
+
+    // Every expected message must be present in the received messages (order independent,
+    // extra received messages like active sensing are tolerated).
+    static boolean midiMessagesMatch(List<byte[]> expected, List<byte[]> received) {
+        for (byte[] expectedMessage : expected) {
+            boolean found = received.stream().anyMatch(actual -> Arrays.equals(actual, expectedMessage));
+
+            if (!found) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static List<byte[]> toByteList(List<MidiMessage> messages) {
+        List<byte[]> list = new ArrayList<>();
+
+        for (MidiMessage message : messages) {
+            list.add(message.getMessage());
+        }
+
+        return list;
+    }
+
+    protected void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static SystemTestStep passed(String name, String message) {
+        return new SystemTestStep(name, true, message);
+    }
+
+    private static SystemTestStep failed(String name, String message) {
+        return new SystemTestStep(name, false, message);
+    }
+
+    private static SystemTestStep skipped(String name, String message) {
+        SystemTestStep step = new SystemTestStep(name, true, message);
+        step.setSkipped(true);
+        return step;
+    }
+
+}

--- a/src/main/java/com/ascargon/rocketshow/health/HealthService.java
+++ b/src/main/java/com/ascargon/rocketshow/health/HealthService.java
@@ -7,6 +7,6 @@ public interface HealthService {
 
     HealthStatus getHealthStatus();
 
-    void testSystem();
+    SystemTestResult testSystem();
 
 }

--- a/src/main/java/com/ascargon/rocketshow/health/SystemTestResult.java
+++ b/src/main/java/com/ascargon/rocketshow/health/SystemTestResult.java
@@ -1,0 +1,30 @@
+package com.ascargon.rocketshow.health;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The aggregated result of a system self-test, consisting of one {@link SystemTestStep}
+ * per checked subsystem (composition playback, GPIO, MIDI, ...).
+ */
+@Getter
+@Setter
+public class SystemTestResult {
+
+    // True as long as no executed (non-skipped) check failed
+    private boolean success = true;
+
+    private List<SystemTestStep> steps = new ArrayList<>();
+
+    public void addStep(SystemTestStep step) {
+        steps.add(step);
+
+        if (!step.isSkipped() && !step.isSuccess()) {
+            success = false;
+        }
+    }
+
+}

--- a/src/main/java/com/ascargon/rocketshow/health/SystemTestService.java
+++ b/src/main/java/com/ascargon/rocketshow/health/SystemTestService.java
@@ -1,0 +1,14 @@
+package com.ascargon.rocketshow.health;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Run an on-device self-test, exercising the connected hardware (audio/video via the
+ * default composition, GPIO outputs and MIDI) and reporting the result per subsystem.
+ */
+@Service
+public interface SystemTestService {
+
+    SystemTestResult runSystemTest();
+
+}

--- a/src/main/java/com/ascargon/rocketshow/health/SystemTestStep.java
+++ b/src/main/java/com/ascargon/rocketshow/health/SystemTestStep.java
@@ -1,0 +1,35 @@
+package com.ascargon.rocketshow.health;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The result of a single check within a system self-test (e.g. MIDI loopback).
+ */
+@Getter
+@Setter
+public class SystemTestStep {
+
+    private String name;
+
+    // Whether the check passed. Skipped checks are also reported as successful so they
+    // don't fail the overall self-test.
+    private boolean success;
+
+    // A check that could not be run because the required hardware/configuration was not
+    // present (e.g. GPIO disabled). Skipped checks do not fail the overall self-test.
+    private boolean skipped;
+
+    // A human readable description of the outcome
+    private String message;
+
+    public SystemTestStep() {
+    }
+
+    public SystemTestStep(String name, boolean success, String message) {
+        this.name = name;
+        this.success = success;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/ascargon/rocketshow/midi/MidiMessageParser.java
+++ b/src/main/java/com/ascargon/rocketshow/midi/MidiMessageParser.java
@@ -85,6 +85,13 @@ public class MidiMessageParser {
 
         // Data byte, possibly part of running status
         if (runningStatus >= 0x80) {
+            // Running status: when a new message starts without a repeated status byte,
+            // the buffer is empty, so re-insert the (implied) status byte first. Otherwise
+            // the message would always be one byte short and never be completed.
+            if (buffer.size() == 0) {
+                buffer.write((byte) runningStatus);
+            }
+
             buffer.write(b);
             int expectedLength = getMidiMessageLength(runningStatus);
 

--- a/src/test/java/com/ascargon/rocketshow/health/DefaultHealthServiceTest.java
+++ b/src/test/java/com/ascargon/rocketshow/health/DefaultHealthServiceTest.java
@@ -35,6 +35,7 @@ class DefaultHealthServiceTest {
         RaucService raucService = mock(RaucService.class);
         DeviceInformationService deviceInformationService = mock(DeviceInformationService.class);
         EepromService eepromService = mock(EepromService.class);
+        SystemTestService systemTestService = mock(SystemTestService.class);
 
         DiskSpace diskSpace = new DiskSpace();
         diskSpace.setUsedMB(50);
@@ -57,7 +58,8 @@ class DefaultHealthServiceTest {
                 versionService,
                 raucService,
                 deviceInformationService,
-                eepromService
+                eepromService,
+                systemTestService
         );
 
         HealthStatus healthStatus = healthService.getHealthStatus();

--- a/src/test/java/com/ascargon/rocketshow/health/DefaultSystemTestServiceTest.java
+++ b/src/test/java/com/ascargon/rocketshow/health/DefaultSystemTestServiceTest.java
@@ -1,0 +1,335 @@
+package com.ascargon.rocketshow.health;
+
+import com.ascargon.rocketshow.composition.Composition;
+import com.ascargon.rocketshow.composition.CompositionService;
+import com.ascargon.rocketshow.midi.MidiDeviceInService;
+import com.ascargon.rocketshow.midi.MidiDeviceOutService;
+import com.ascargon.rocketshow.play.CompositionPlayer;
+import com.ascargon.rocketshow.play.PlayerService;
+import com.ascargon.rocketshow.raspberry.ActionRaspberryGpio;
+import com.ascargon.rocketshow.raspberry.RaspberryGpioOutService;
+import com.ascargon.rocketshow.settings.Settings;
+import com.ascargon.rocketshow.settings.SettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.sound.midi.MidiMessage;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultSystemTestServiceTest {
+
+    private SettingsService settingsService;
+    private Settings settings;
+    private CompositionService compositionService;
+    private PlayerService playerService;
+    private MidiDeviceInService midiDeviceInService;
+    private MidiDeviceOutService midiDeviceOutService;
+    private RaspberryGpioOutService raspberryGpioOutService;
+
+    private TestableSystemTestService systemTestService;
+
+    /**
+     * A subclass that removes the timing/hardware seams so the orchestration can be tested
+     * deterministically: sleeps are skipped and the MIDI loopback capture is stubbed.
+     */
+    private static class TestableSystemTestService extends DefaultSystemTestService {
+
+        boolean midiReturnNull = false;
+        boolean midiEcho = false;
+        List<byte[]> midiCaptureResult = new ArrayList<>();
+        List<MidiMessage> capturedSentMessages;
+
+        CompositionPlayer.PlayState testPlayState = CompositionPlayer.PlayState.PLAYING;
+        boolean throwOnPlayStateCheck = false;
+
+        TestableSystemTestService(SettingsService settingsService, CompositionService compositionService,
+                                  PlayerService playerService, MidiDeviceInService midiDeviceInService,
+                                  MidiDeviceOutService midiDeviceOutService,
+                                  RaspberryGpioOutService raspberryGpioOutService) {
+            super(settingsService, compositionService, playerService, midiDeviceInService,
+                    midiDeviceOutService, raspberryGpioOutService);
+        }
+
+        @Override
+        protected void sleep(long millis) {
+            // no-op to keep the tests fast and deterministic
+        }
+
+        @Override
+        protected CompositionPlayer.PlayState getTestCompositionPlayState() {
+            if (throwOnPlayStateCheck) {
+                throw new RuntimeException("boom");
+            }
+            return testPlayState;
+        }
+
+        @Override
+        protected List<byte[]> sendAndCaptureMidi(List<MidiMessage> messages) {
+            capturedSentMessages = messages;
+
+            if (midiReturnNull) {
+                return null;
+            }
+
+            if (midiEcho) {
+                List<byte[]> echoed = new ArrayList<>();
+                for (MidiMessage message : messages) {
+                    echoed.add(message.getMessage());
+                }
+                return echoed;
+            }
+
+            return midiCaptureResult;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        settingsService = mock(SettingsService.class);
+        settings = mock(Settings.class);
+        compositionService = mock(CompositionService.class);
+        playerService = mock(PlayerService.class);
+        midiDeviceInService = mock(MidiDeviceInService.class);
+        midiDeviceOutService = mock(MidiDeviceOutService.class);
+        raspberryGpioOutService = mock(RaspberryGpioOutService.class);
+
+        when(settingsService.getSettings()).thenReturn(settings);
+
+        // Sensible defaults: nothing configured, no hardware
+        when(settings.getDefaultComposition()).thenReturn(null);
+        when(settings.getEnableRaspberryGpio()).thenReturn(false);
+        when(settings.getRaspberryGpioOutputPinBcmList()).thenReturn(new ArrayList<>());
+        when(midiDeviceOutService.isConnected()).thenReturn(false);
+
+        systemTestService = new TestableSystemTestService(settingsService, compositionService, playerService,
+                midiDeviceInService, midiDeviceOutService, raspberryGpioOutService);
+    }
+
+    // --- Default composition --------------------------------------------------------------
+
+    @Test
+    void defaultCompositionSkippedWhenNotConfigured() {
+        when(settings.getDefaultComposition()).thenReturn("");
+
+        SystemTestStep step = systemTestService.testDefaultComposition();
+
+        assertTrue(step.isSkipped());
+        assertTrue(step.isSuccess());
+    }
+
+    @Test
+    void defaultCompositionFailsWhenNotFound() {
+        when(settings.getDefaultComposition()).thenReturn("missing");
+        when(compositionService.getComposition("missing")).thenReturn(null);
+
+        SystemTestStep step = systemTestService.testDefaultComposition();
+
+        assertFalse(step.isSkipped());
+        assertFalse(step.isSuccess());
+    }
+
+    @Test
+    void defaultCompositionPassesWhenPlaying() throws Exception {
+        when(settings.getDefaultComposition()).thenReturn("demo");
+        when(compositionService.getComposition("demo")).thenReturn(mock(Composition.class));
+        systemTestService.testPlayState = CompositionPlayer.PlayState.PLAYING;
+
+        SystemTestStep step = systemTestService.testDefaultComposition();
+
+        assertTrue(step.isSuccess());
+        assertFalse(step.isSkipped());
+        verify(playerService).playTestComposition(any());
+        verify(playerService).stopTestComposition();
+    }
+
+    @Test
+    void defaultCompositionFailsWhenNotReachingPlayingState() {
+        when(settings.getDefaultComposition()).thenReturn("demo");
+        when(compositionService.getComposition("demo")).thenReturn(mock(Composition.class));
+        systemTestService.testPlayState = CompositionPlayer.PlayState.STOPPED;
+
+        SystemTestStep step = systemTestService.testDefaultComposition();
+
+        assertFalse(step.isSuccess());
+    }
+
+    @Test
+    void defaultCompositionStopsEvenWhenStateCheckThrows() throws Exception {
+        when(settings.getDefaultComposition()).thenReturn("demo");
+        when(compositionService.getComposition("demo")).thenReturn(mock(Composition.class));
+        systemTestService.throwOnPlayStateCheck = true;
+
+        SystemTestStep step = systemTestService.testDefaultComposition();
+
+        assertFalse(step.isSuccess());
+        // The composition was started, so it must be stopped again even after the error
+        verify(playerService).stopTestComposition();
+    }
+
+    // --- GPIO -----------------------------------------------------------------------------
+
+    @Test
+    void gpioSkippedWhenDisabled() {
+        when(settings.getEnableRaspberryGpio()).thenReturn(false);
+
+        SystemTestStep step = systemTestService.testGpioOutputs();
+
+        assertTrue(step.isSkipped());
+        verify(raspberryGpioOutService, never()).executeAction(any());
+    }
+
+    @Test
+    void gpioSkippedWhenNoPinsConfigured() {
+        when(settings.getEnableRaspberryGpio()).thenReturn(true);
+        when(settings.getRaspberryGpioOutputPinBcmList()).thenReturn(new ArrayList<>());
+
+        SystemTestStep step = systemTestService.testGpioOutputs();
+
+        assertTrue(step.isSkipped());
+        verify(raspberryGpioOutService, never()).executeAction(any());
+    }
+
+    @Test
+    void gpioTogglesEachConfiguredPinHighThenLow() {
+        when(settings.getEnableRaspberryGpio()).thenReturn(true);
+        when(settings.getRaspberryGpioOutputPinBcmList()).thenReturn(List.of(17, 27));
+
+        SystemTestStep step = systemTestService.testGpioOutputs();
+
+        assertTrue(step.isSuccess());
+        assertFalse(step.isSkipped());
+
+        ArgumentCaptor<ActionRaspberryGpio> captor = ArgumentCaptor.forClass(ActionRaspberryGpio.class);
+        // 2 pins x (high + low) = 4 actions
+        verify(raspberryGpioOutService, times(4)).executeAction(captor.capture());
+
+        List<ActionRaspberryGpio> actions = captor.getAllValues();
+        assertEquals(17, actions.get(0).getPinId());
+        assertTrue(actions.get(0).getHigh());
+        assertEquals(17, actions.get(1).getPinId());
+        assertFalse(actions.get(1).getHigh());
+        assertEquals(27, actions.get(2).getPinId());
+        assertTrue(actions.get(2).getHigh());
+        assertEquals(27, actions.get(3).getPinId());
+        assertFalse(actions.get(3).getHigh());
+    }
+
+    // --- MIDI -----------------------------------------------------------------------------
+
+    @Test
+    void midiSkippedWhenOutNotConnected() {
+        when(midiDeviceOutService.isConnected()).thenReturn(false);
+
+        SystemTestStep step = systemTestService.testMidiLoopback();
+
+        assertTrue(step.isSkipped());
+    }
+
+    @Test
+    void midiSkippedWhenNoInDevice() {
+        when(midiDeviceOutService.isConnected()).thenReturn(true);
+        systemTestService.midiReturnNull = true;
+
+        SystemTestStep step = systemTestService.testMidiLoopback();
+
+        assertTrue(step.isSkipped());
+    }
+
+    @Test
+    void midiPassesWhenLoopbackEchoesMessages() {
+        when(midiDeviceOutService.isConnected()).thenReturn(true);
+        systemTestService.midiEcho = true;
+
+        SystemTestStep step = systemTestService.testMidiLoopback();
+
+        assertTrue(step.isSuccess());
+        assertFalse(step.isSkipped());
+        assertFalse(systemTestService.capturedSentMessages.isEmpty());
+    }
+
+    @Test
+    void midiFailsWhenNothingReceived() {
+        when(midiDeviceOutService.isConnected()).thenReturn(true);
+        systemTestService.midiCaptureResult = new ArrayList<>();
+
+        SystemTestStep step = systemTestService.testMidiLoopback();
+
+        assertFalse(step.isSuccess());
+        assertFalse(step.isSkipped());
+    }
+
+    // --- Aggregation ----------------------------------------------------------------------
+
+    @Test
+    void runSystemTestSucceedsWhenAllStepsPassOrSkip() throws Exception {
+        when(settings.getDefaultComposition()).thenReturn("demo");
+        when(compositionService.getComposition("demo")).thenReturn(mock(Composition.class));
+        systemTestService.testPlayState = CompositionPlayer.PlayState.PLAYING;
+        when(midiDeviceOutService.isConnected()).thenReturn(true);
+        systemTestService.midiEcho = true;
+
+        SystemTestResult result = systemTestService.runSystemTest();
+
+        assertTrue(result.isSuccess());
+        assertEquals(3, result.getSteps().size());
+    }
+
+    @Test
+    void runSystemTestFailsWhenAStepFails() {
+        // Default composition configured but missing -> failing step
+        when(settings.getDefaultComposition()).thenReturn("missing");
+        when(compositionService.getComposition("missing")).thenReturn(null);
+
+        SystemTestResult result = systemTestService.runSystemTest();
+
+        assertFalse(result.isSuccess());
+        assertEquals(3, result.getSteps().size());
+    }
+
+    @Test
+    void runSystemTestSucceedsWhenEverythingIsSkipped() {
+        // All defaults: nothing configured/connected -> all steps skipped
+        SystemTestResult result = systemTestService.runSystemTest();
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getSteps().stream().allMatch(SystemTestStep::isSkipped));
+    }
+
+    // --- MIDI message matching helper -----------------------------------------------------
+
+    @Test
+    void midiMessagesMatchReturnsTrueWhenAllExpectedPresent() {
+        List<byte[]> expected = List.of(new byte[]{0x10, 0x20}, new byte[]{0x30});
+        List<byte[]> received = List.of(new byte[]{0x30}, new byte[]{0x10, 0x20});
+
+        assertTrue(DefaultSystemTestService.midiMessagesMatch(expected, received));
+    }
+
+    @Test
+    void midiMessagesMatchToleratesExtraReceivedMessages() {
+        List<byte[]> expected = List.of(new byte[]{0x10});
+        List<byte[]> received = List.of(new byte[]{0x10}, new byte[]{(byte) 0xFE});
+
+        assertTrue(DefaultSystemTestService.midiMessagesMatch(expected, received));
+    }
+
+    @Test
+    void midiMessagesMatchReturnsFalseWhenExpectedMissing() {
+        List<byte[]> expected = List.of(new byte[]{0x10}, new byte[]{0x40});
+        List<byte[]> received = List.of(new byte[]{0x10});
+
+        assertFalse(DefaultSystemTestService.midiMessagesMatch(expected, received));
+    }
+}

--- a/src/test/java/com/ascargon/rocketshow/lighting/DefaultMidi2LightingConvertServiceTest.java
+++ b/src/test/java/com/ascargon/rocketshow/lighting/DefaultMidi2LightingConvertServiceTest.java
@@ -1,0 +1,70 @@
+package com.ascargon.rocketshow.lighting;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.sound.midi.ShortMessage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class DefaultMidi2LightingConvertServiceTest {
+
+    private LightingService lightingService;
+    private DefaultMidi2LightingConvertService convertService;
+    private Midi2LightingMapping mapping;
+    private LightingUniverseState universeState;
+
+    @BeforeEach
+    void setUp() {
+        lightingService = mock(LightingService.class);
+        convertService = new DefaultMidi2LightingConvertService(lightingService);
+        // The default mapping type is SIMPLE
+        mapping = new Midi2LightingMapping();
+        universeState = new LightingUniverseState();
+    }
+
+    @Test
+    void noteOnMapsVelocityTimesTwoToTheChannel() throws Exception {
+        ShortMessage message = new ShortMessage(ShortMessage.NOTE_ON, 0, 10, 100);
+
+        convertService.processMidiEvent(message, mapping, universeState);
+
+        assertEquals(200, universeState.getUniverse().get(10));
+        verify(lightingService).send();
+    }
+
+    @Test
+    void noteOnExtendsAlmostMaxValueToFullMax() throws Exception {
+        // Velocity 127 -> 254, which is extended to the full 255
+        ShortMessage message = new ShortMessage(ShortMessage.NOTE_ON, 0, 5, 127);
+
+        convertService.processMidiEvent(message, mapping, universeState);
+
+        assertEquals(255, universeState.getUniverse().get(5));
+    }
+
+    @Test
+    void noteOffResetsTheChannelToZero() throws Exception {
+        universeState.getUniverse().put(10, 200);
+
+        ShortMessage message = new ShortMessage(ShortMessage.NOTE_OFF, 0, 10, 0);
+        convertService.processMidiEvent(message, mapping, universeState);
+
+        assertEquals(0, universeState.getUniverse().get(10));
+        verify(lightingService).send();
+    }
+
+    @Test
+    void nonNoteMessagesAreIgnored() throws Exception {
+        ShortMessage message = new ShortMessage(ShortMessage.CONTROL_CHANGE, 0, 10, 100);
+
+        convertService.processMidiEvent(message, mapping, universeState);
+
+        assertTrue(universeState.getUniverse().isEmpty());
+        verify(lightingService, never()).send();
+    }
+}

--- a/src/test/java/com/ascargon/rocketshow/midi/MidiMapperTest.java
+++ b/src/test/java/com/ascargon/rocketshow/midi/MidiMapperTest.java
@@ -1,0 +1,116 @@
+package com.ascargon.rocketshow.midi;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.SysexMessage;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MidiMapperTest {
+
+    private ShortMessage noteOn(int channel, int note, int velocity) throws Exception {
+        return new ShortMessage(ShortMessage.NOTE_ON, channel, note, velocity);
+    }
+
+    private ChannelMapping channelMapping(int from, int to) {
+        ChannelMapping channelMapping = new ChannelMapping();
+        channelMapping.setChannelFrom(from);
+        channelMapping.setChannelTo(to);
+        return channelMapping;
+    }
+
+    @Test
+    void mapsChannelAccordingToChannelMap() throws Exception {
+        MidiMapping mapping = new MidiMapping();
+        mapping.setChannelMap(List.of(channelMapping(0, 5)));
+
+        ShortMessage message = noteOn(0, 60, 100);
+        MidiMapper.processMidiEvent(message, mapping);
+
+        assertEquals(5, message.getChannel());
+        assertEquals(60, message.getData1());
+    }
+
+    @Test
+    void appliesChannelOffset() throws Exception {
+        MidiMapping mapping = new MidiMapping();
+        mapping.setChannelOffset(2);
+
+        ShortMessage message = noteOn(1, 60, 100);
+        MidiMapper.processMidiEvent(message, mapping);
+
+        // No channel map -> channelTo == channelFrom (1), plus the offset (2)
+        assertEquals(3, message.getChannel());
+    }
+
+    @Test
+    void appliesNoteOffset() throws Exception {
+        MidiMapping mapping = new MidiMapping();
+        mapping.setNoteOffset(12);
+
+        ShortMessage message = noteOn(0, 60, 100);
+        MidiMapper.processMidiEvent(message, mapping);
+
+        assertEquals(72, message.getData1());
+    }
+
+    @Test
+    void inheritsChannelMapFromParentWhenNotOverridden() throws Exception {
+        MidiMapping parent = new MidiMapping();
+        parent.setChannelMap(List.of(channelMapping(0, 7)));
+
+        MidiMapping child = new MidiMapping();
+        child.setParent(parent);
+
+        ShortMessage message = noteOn(0, 60, 100);
+        MidiMapper.processMidiEvent(message, child);
+
+        assertEquals(7, message.getChannel());
+    }
+
+    @Test
+    void ignoresParentMappingWhenParentOverridesItsChildren() throws Exception {
+        MidiMapping parent = new MidiMapping();
+        parent.setChannelMap(List.of(channelMapping(0, 7)));
+        parent.setOverrideParent(true);
+
+        MidiMapping child = new MidiMapping();
+        child.setParent(parent);
+
+        ShortMessage message = noteOn(0, 60, 100);
+        MidiMapper.processMidiEvent(message, child);
+
+        // Parent declares itself as overriding -> its mapping must not be consulted
+        assertEquals(0, message.getChannel());
+    }
+
+    @Test
+    void leavesNonNoteMessagesUnchanged() throws Exception {
+        MidiMapping mapping = new MidiMapping();
+        mapping.setChannelOffset(3);
+        mapping.setNoteOffset(12);
+
+        ShortMessage message = new ShortMessage(ShortMessage.CONTROL_CHANGE, 0, 10, 100);
+        MidiMapper.processMidiEvent(message, mapping);
+
+        assertEquals(0, message.getChannel());
+        assertEquals(10, message.getData1());
+    }
+
+    @Test
+    void leavesNonShortMessagesUnchanged() throws Exception {
+        MidiMapping mapping = new MidiMapping();
+        mapping.setNoteOffset(12);
+
+        byte[] data = {(byte) 0xF0, 0x7E, (byte) 0xF7};
+        SysexMessage message = new SysexMessage(data, data.length);
+
+        // Must not throw and must not modify the message
+        MidiMapper.processMidiEvent(message, mapping);
+
+        assertEquals(3, message.getLength());
+    }
+}

--- a/src/test/java/com/ascargon/rocketshow/midi/MidiMessageParserTest.java
+++ b/src/test/java/com/ascargon/rocketshow/midi/MidiMessageParserTest.java
@@ -1,0 +1,122 @@
+package com.ascargon.rocketshow.midi;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.SysexMessage;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MidiMessageParserTest {
+
+    @Test
+    void offerByteAssemblesThreeByteNoteOn() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        // Status and first data byte do not complete the message yet
+        assertTrue(parser.offerByte((byte) 0x90).isEmpty());
+        assertTrue(parser.offerByte((byte) 0x3C).isEmpty());
+
+        Optional<MidiMessage> result = parser.offerByte((byte) 0x64);
+
+        assertTrue(result.isPresent());
+        ShortMessage message = assertInstanceOf(ShortMessage.class, result.get());
+        assertEquals(ShortMessage.NOTE_ON, message.getCommand());
+        assertEquals(0, message.getChannel());
+        assertEquals(0x3C, message.getData1());
+        assertEquals(0x64, message.getData2());
+    }
+
+    @Test
+    void offerByteAssemblesTwoByteProgramChange() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        assertTrue(parser.offerByte((byte) 0xC0).isEmpty());
+        Optional<MidiMessage> result = parser.offerByte((byte) 0x05);
+
+        assertTrue(result.isPresent());
+        ShortMessage message = assertInstanceOf(ShortMessage.class, result.get());
+        assertEquals(ShortMessage.PROGRAM_CHANGE, message.getCommand());
+        assertEquals(0x05, message.getData1());
+    }
+
+    @Test
+    void offerByteEmitsSingleByteRealTimeMessageImmediately() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        // 0xF8 = timing clock, a one-byte real-time message
+        Optional<MidiMessage> result = parser.offerByte((byte) 0xF8);
+
+        assertTrue(result.isPresent());
+        assertEquals(0xF8, result.get().getStatus());
+        assertEquals(1, result.get().getLength());
+    }
+
+    @Test
+    void offerByteAssemblesTwoByteQuarterFrame() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        // 0xF1 = MIDI timecode quarter frame (2 bytes)
+        assertTrue(parser.offerByte((byte) 0xF1).isEmpty());
+        Optional<MidiMessage> result = parser.offerByte((byte) 0x09);
+
+        assertTrue(result.isPresent());
+        assertEquals(0xF1, result.get().getStatus());
+    }
+
+    @Test
+    void offerByteAccumulatesSysExUntilEndMarker() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        byte[] sysEx = {(byte) 0xF0, 0x7E, 0x00, 0x06, 0x01, (byte) 0xF7};
+
+        for (int i = 0; i < sysEx.length - 1; i++) {
+            assertTrue(parser.offerByte(sysEx[i]).isEmpty(), "byte " + i + " should not complete the message");
+        }
+
+        Optional<MidiMessage> result = parser.offerByte(sysEx[sysEx.length - 1]);
+
+        assertTrue(result.isPresent());
+        SysexMessage message = assertInstanceOf(SysexMessage.class, result.get());
+        assertArrayEquals(sysEx, message.getMessage());
+    }
+
+    @Test
+    void offerBytesReturnsTheLastCompletedMessage() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        // Two complete NOTE_ON messages in a single chunk
+        Optional<MidiMessage> result = parser.offerBytes(new byte[]{
+                (byte) 0x90, 0x3C, 0x64,
+                (byte) 0x90, 0x3E, 0x40
+        });
+
+        assertTrue(result.isPresent());
+        ShortMessage message = assertInstanceOf(ShortMessage.class, result.get());
+        assertEquals(0x3E, message.getData1());
+        assertEquals(0x40, message.getData2());
+    }
+
+    @Test
+    void offerBytesIsEmptyForIncompleteMessage() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        assertFalse(parser.offerBytes(new byte[]{(byte) 0x90, 0x3C}).isPresent());
+    }
+
+    @Test
+    void createMidiMessageFromBytesBuildsNoteOff() throws Exception {
+        MidiMessage message = MidiMessageParser.createMidiMessageFromBytes(new byte[]{(byte) 0x80, 0x3C, 0x00}, 3);
+
+        ShortMessage shortMessage = assertInstanceOf(ShortMessage.class, message);
+        assertEquals(ShortMessage.NOTE_OFF, shortMessage.getCommand());
+        assertEquals(0x3C, shortMessage.getData1());
+    }
+}

--- a/src/test/java/com/ascargon/rocketshow/midi/MidiMessageParserTest.java
+++ b/src/test/java/com/ascargon/rocketshow/midi/MidiMessageParserTest.java
@@ -105,6 +105,26 @@ class MidiMessageParserTest {
     }
 
     @Test
+    void offerByteSupportsRunningStatus() throws Exception {
+        MidiMessageParser parser = new MidiMessageParser();
+
+        // First a full NOTE_ON message including its status byte
+        parser.offerByte((byte) 0x90);
+        parser.offerByte((byte) 0x3C);
+        assertTrue(parser.offerByte((byte) 0x64).isPresent());
+
+        // Then a second NOTE_ON sent in running status (data bytes only, no status byte)
+        assertTrue(parser.offerByte((byte) 0x3E).isEmpty());
+        Optional<MidiMessage> result = parser.offerByte((byte) 0x40);
+
+        assertTrue(result.isPresent());
+        ShortMessage message = assertInstanceOf(ShortMessage.class, result.get());
+        assertEquals(ShortMessage.NOTE_ON, message.getCommand());
+        assertEquals(0x3E, message.getData1());
+        assertEquals(0x40, message.getData2());
+    }
+
+    @Test
     void offerBytesIsEmptyForIncompleteMessage() throws Exception {
         MidiMessageParser parser = new MidiMessageParser();
 


### PR DESCRIPTION
## Summary

Turns the empty `HealthService.testSystem()` stub into a real on-device self-test for the connected hardware, adds unit-test coverage for previously-untested core logic (and fixes a bug found along the way), and wires up CI so tests run automatically.

## Changes

### 1. System self-test (replaces the `testSystem()` TODO stub)
A new `SystemTestService` / `DefaultSystemTestService` runs three checks and returns a structured `SystemTestResult` (per-subsystem `pass` / `fail` / `skipped`), mirroring the existing `HealthStatus` pattern:

- **Default composition playback** — plays the configured default composition via the test player and verifies it reaches `PLAYING` (catches audio/video/lighting pipeline errors).
- **GPIO outputs** — toggles every configured output pin high → low.
- **MIDI loopback** — sends MIDI messages to the out device and verifies the same messages arrive on the in device (requires a loopback cable).

Checks that can't run (hardware/config missing) are reported as **skipped** and don't fail the overall result. `HealthService.testSystem()` now returns the result and `POST /system/test` exposes it.

### 2. Unit tests for core logic
- `DefaultSystemTestServiceTest` — orchestration, each subsystem check, cleanup-on-error, result aggregation, MIDI-matching helper (uses protected seams so no real hardware is needed).
- `MidiMessageParserTest` — byte-stream parsing: note on/off, program change, real-time, quarter-frame, SysEx, running status, chunked input, static factory.
- `MidiMapperTest` — channel map, channel/note offsets, parent-chain inheritance, override, non-note handling.
- `DefaultMidi2LightingConvertServiceTest` — SIMPLE MIDI→DMX mapping with a mocked `LightingService` (velocity×2, 254→255 extension, note-off reset, ignore non-note).

### 3. Bug fix — MIDI running status
`MidiMessageParser` silently dropped messages sent in **running status** (data bytes with no repeated status byte): after a completed message the buffer is empty, but the data-byte branch compared its size against the full expected length (including the status byte), so the message was always one byte short and never emitted. The implied status byte is now re-inserted when a new message starts with an empty buffer. Covered by a regression test.

### 4. CI
New `.github/workflows/ci.yml`: runs the backend unit tests on JDK 21 for every push and pull request. The Angular frontend build is skipped in CI (`skip.installnodenpm` / `skip.npm`) to avoid a Node toolchain and keep runs fast; it still runs during regular packaging.

## Testing

Full suite run exactly as CI runs it: **45 tests, BUILD SUCCESS**, including the `@SpringBootTest` context load (headless), confirming the new bean wires cleanly.

## Notes / possible follow-ups

- GPIO verification is output-only today — there's no GPIO input-read API, so pins are toggled and reported rather than read back. Adding an input-read method would enable a true GPIO loopback assertion.
- Audio is verified indirectly (composition reaches `PLAYING`); full line-out→line-in capture/analysis would be a larger follow-up.
- The `POST /system/test` endpoint now returns a structured `SystemTestResult` that the frontend could surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNnMyxiyKEox2VM6C2Ri1w)_