### PR TITLE
Fix errors in reworked Raspberry Pi OS build script

### DIFF
--- a/dist/install/raspbian.sh
+++ b/dist/install/raspbian.sh
@@ -14,7 +14,7 @@ echo "Install packages"
 apt-get update
 apt-get upgrade -y
 
-apt-get -y install unzip openjdk-21-jdk dhcpcd dnsmasq hostapd fbi ola libnss-mdns iptables libasound2 alsa-utils openssh-sftp-server libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-gl
+apt-get -y install unzip openjdk-21-jdk dhcpcd dnsmasq hostapd fbi ola libnss-mdns iptables netcat-openbsd libasound2 alsa-utils openssh-sftp-server libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-gl
 
 # ---- USER MANAGEMENT ----
 # Add the rocketshow user
@@ -119,7 +119,8 @@ listen-address=192.168.4.1
 dhcp-range=192.168.4.2,192.168.4.20,255.255.255.0,24h
 EOF
 
-cat <<'EOF' >hostapd.conf
+install -d /etc/hostapd
+cat <<'EOF' >/etc/hostapd/hostapd.conf
 interface=wlan0
 driver=nl80211
 ssid=Rocket Show
@@ -347,7 +348,6 @@ WorkingDirectory=/opt/rocketshow
 
 # Main process: KEEP IN FOREGROUND (no &)
 # Wait for port 9010 from OLA to be ready before starting the app
-[Service]
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 120); do nc -z 127.0.0.1 9010 && exit 0; echo "Waiting for olad on :9010 ($i/120)"; sleep 1; done; echo "olad not ready"; exit 1'
 ExecStart=/usr/bin/java -Xmx512m -jar /opt/rocketshow/rocketshow.jar
 


### PR DESCRIPTION
The Raspberry Pi OS build script (`dist/install/raspbian.sh`) was heavily reworked and not yet tested. Reviewing it against how the Java app actually consumes the files it generates surfaced three bugs, all fixed here.

## Fixes

1. **`hostapd.conf` written to the wrong location.** The heredoc used `>hostapd.conf`, writing to the working directory (`/opt/rocketshow/hostapd.conf`), while the following `chmod 777 /etc/hostapd/hostapd.conf` and the app itself (`DefaultSettingsUpdateSystemService.java:221`, `FileWriter("/etc/hostapd/hostapd.conf")`) both use `/etc/hostapd/hostapd.conf`. The initial config never landed where hostapd/the app expect it, and the `chmod` operated on a non-existent file. Now writes to `/etc/hostapd/hostapd.conf`, with `install -d /etc/hostapd` to guarantee the directory exists.

2. **`nc` used but never installed.** `rocketshow.service`'s `ExecStartPre` waits for olad with `nc -z 127.0.0.1 9010`, but netcat is not present on Raspberry Pi OS Lite by default. The probe would fail on every iteration, hit the 120s timeout, and the app would never start. Added `netcat-openbsd` to the `apt-get install` list.

3. **Duplicate `[Service]` section in `rocketshow.service`.** systemd merges duplicate sections so it happened to work, but it is fragile and confusing. Consolidated into a single `[Service]` section.

## Verification

- `bash -n` passes on the main script and on both embedded heredoc scripts (`set-wifi-ap-country.sh`, `set-lan-ip.sh`).

## Not addressed (flagged for follow-up)

- **Mixed network stack:** wlan0's AP still uses the old `dhcpcd.conf` static-IP approach while the LAN script uses NetworkManager/`nmcli`. On Bookworm/Trixie, NetworkManager is the default renderer, so the two can contend over interfaces. This is an architectural decision rather than a clear scripting bug, so it was left as-is.
- **Initial `hostapd.conf` is technically invalid** (`wpa_key_mgmt=WPA-PSK` with no `wpa=`/`wpa_passphrase`). Harmless as a placeholder since hostapd is not enabled at install time and the app rewrites it — but note the app produces the same invalid combination for a passphrase-less (open) AP, which would make hostapd refuse to start. That is a Java-side issue, outside this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012vB4DpQoBiqfoURNgbxrzg)_