### PR TITLE
Handle update interrupted during installation

### DIFF
--- a/src/main/java/com/ascargon/rocketshow/update/DefaultUpdateService.java
+++ b/src/main/java/com/ascargon/rocketshow/update/DefaultUpdateService.java
@@ -67,6 +67,11 @@ public class DefaultUpdateService implements UpdateService {
             } else if (UpdateStep.FALLING_BACK.equals(updateState.getStep())) {
                 // We booted back into the original slot after the update failed
                 error("Update failed. Reverted original state.");
+            } else if (UpdateStep.UPDATING.equals(updateState.getStep())) {
+                // We got interrupted (e.g. by a reboot or crash) while still installing.
+                // The installation runs synchronously in the update process and cannot be
+                // resumed, so mark the update as failed instead of waiting forever.
+                error("Update was interrupted during installation.");
             }
         }
     }

--- a/src/main/webapp/src/app/update-progress/update-progress.component.ts
+++ b/src/main/webapp/src/app/update-progress/update-progress.component.ts
@@ -34,57 +34,59 @@ export class UpdateProgressComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
+    // The websocket gives smooth progress while installing.
     this.updateStateServiceSubscription = this.updateStateService.updateState.subscribe((updateState: UpdateState) => {
       this.processUpdateState(updateState);
     });
 
-    // Seed the current state, because the websocket only pushes future changes
-    // (e.g. right after a page reload there might not be a new state for a while).
+    // Poll the current state as a reliable fallback. The websocket only pushes
+    // future changes, so it can miss the final state after a reboot: e.g. when an
+    // update is interrupted while installing, the backend marks it as failed on
+    // startup before any client is connected, and no state is pushed afterwards.
+    // Seed immediately and keep polling until the update is done or has failed.
+    this.pollUpdateState();
+    this.pollStateInterval = setInterval(() => this.pollUpdateState(), 5000);
+  }
+
+  private pollUpdateState() {
     this.updateService.getUpdateState().subscribe((updateState) => {
       this.processUpdateState(updateState);
     });
   }
 
+  private stopPolling() {
+    if (this.pollStateInterval) {
+      clearInterval(this.pollStateInterval);
+      this.pollStateInterval = undefined;
+    }
+  }
+
   private finishUpdateSuccess() {
     this.updateFinished = true;
     this.updatePerc = 100;
+    this.stopPolling();
   }
 
   private finishUpdateError(error: string) {
     this.updateError = true;
+    this.stopPolling();
     this.toastGeneralErrorService.show(new Error(error));
   }
 
   private processUpdateState(updateState: UpdateState) {
-    if (updateState.step === 'REBOOTING' || updateState.step === 'FALLING_BACK') {
-      this.updateStep = 'settings.update-reboot';
-      this.updatePerc = 99;
-
-      // Don't rely on states pushed from the backend, because it's rebooting now
-      // and we might not be able to reconnect to the websocket in time. Instead, poll
-      // for a new status until the update is finished.
-      if (this.updateStateServiceSubscription) {
-        this.updateStateServiceSubscription.unsubscribe();
-        this.updateStateServiceSubscription = undefined;
+    if (updateState.step === 'FINISHED') {
+      if (this.updateFinished || this.updateError) {
+        // Already handled (e.g. by a concurrent websocket message and poll).
+        return;
       }
-
-      if (!this.pollStateInterval) {
-        this.pollStateInterval = setInterval(() => {
-          this.updateService.getUpdateState().subscribe((polledState) => {
-            if (polledState.step === 'FINISHED') {
-              clearInterval(this.pollStateInterval);
-              this.pollStateInterval = undefined;
-            }
-            this.processUpdateState(polledState);
-          });
-        }, 5000);
-      }
-    } else if (updateState.step === 'FINISHED') {
       if (updateState.error) {
         this.finishUpdateError(updateState.error);
       } else {
         this.finishUpdateSuccess();
       }
+    } else if (updateState.step === 'REBOOTING' || updateState.step === 'FALLING_BACK') {
+      this.updateStep = 'settings.update-reboot';
+      this.updatePerc = 99;
     } else {
       this.updateStep = 'settings.update-install';
       if (updateState.progressPercentage > 98) {


### PR DESCRIPTION
If the device rebooted (or crashed) while still installing, the update state stayed at UPDATING forever: the backend never reset it and the status just waited for an install that was no longer running.

- Backend: on startup, treat a persisted UPDATING step as a failed update, since the synchronous installation cannot be resumed after a restart.
- Frontend: the full-screen update status now polls the update state as a reliable fallback (not only during reboot), so it reaches the terminal done/failed state even when the websocket never re-pushes it after a reboot.


Claude-Session: https://claude.ai/code/session_01LNcWszzttWd3xnEtMYSWoZ